### PR TITLE
Add README to GitHub organization

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,19 @@
+## Hi there 👋
+
+This is the GitHub organization for Swiss GRC, a leading software company in the development and implementation of Governance, Risk & Compliance solutions "Swiss made" for companies worldwide.
+You can find out more about our company and products at [swissgrc.com](https://swissgrc.com/en/).
+
+Here you will find:
+
+🐳 Docker images for using in [Azure Pipelines Container Jobs](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/container-phases):
+
+* [.NET](https://github.com/swissgrc/docker-azure-pipelines-dotnet)
+* [Azure CLI](https://github.com/swissgrc/docker-azure-pipelines-azurecli)
+* [Terraform](https://github.com/swissgrc/docker-azure-pipelines-terraform)
+* [Helm](https://github.com/swissgrc/docker-azure-pipelines-helm)
+* [Markdownlint](https://github.com/swissgrc/docker-azure-pipelines-markdownlint)
+* [Renovate](https://github.com/swissgrc/docker-azure-pipelines-renovate)
+
+📦 NPM packages:
+
+* [PostCSS plugin to remove font faces formats](https://github.com/swissgrc/postcss-remove-font-face-format)


### PR DESCRIPTION
Adds a README to the swissgrc GitHub organization. README will be shown at the top of https://github.com/swissgrc