### PR TITLE
Add flag to indicate whether to tag latest

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -4,6 +4,10 @@ on:
       image-name:
         required: true
         type: string
+      latest-tag:
+        required: true
+        type: boolean
+        default: true
     secrets:
       gh-token:
         required: true
@@ -28,6 +32,8 @@ jobs:
           images: |
             ${{ inputs.image-name }}
             ghcr.io/${{ inputs.image-name }}
+          flavor: |
+            latest=${{ inputs.latest-tag == true && 'auto' || 'false' }}
           tags: |
             type=ref,event=tag
             type=ref,event=pr


### PR DESCRIPTION
This is required for images from multiple git repositories where only one repository will provide the latest tag. 
(For example the net6 & net7 git repositories and only net7 provides the latest tag)

If a caller sets `latest-tag` to `true` we let the docker metadata action decide whether to create the latest tag.
So it behaves the same way as until now: `latest` tag only for GitHub releases)

If a caller sets `latest-tag` to `false `the latest tag will never be automatically created.