### PR TITLE
Make latest-tag input optional

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -5,7 +5,6 @@ on:
         required: true
         type: string
       latest-tag:
-        required: true
         type: boolean
         default: true
     secrets:


### PR DESCRIPTION
`required = true` and `default = true` does not work like expected in GitHub actions.
Thus the latest-tag input must not be set to be required.