### PR TITLE
Support more customized image tags

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
       # Creates an expression to be used in docker/metadata-action
-      - name: Expression for additional latest tag
+      - name: Expressions for additional tags
         id: additional-tags
         run: |
           latestTagName="${{ inputs.additional-latest-tag-name }}"
@@ -70,7 +70,7 @@ jobs:
             # set additional tags if available
             ${{ steps.additional-tags.outputs.latest-expression }}
             ${{ steps.additional-tags.outputs.unstable-expression }}
-            # set unstable tag for develop branch
+            # set default unstable tag for develop branch
             type=raw,value=unstable,enable=${{ inputs.default-unstable-tag == true && github.ref == format('refs/heads/{0}', 'develop') }}
 
       # Build Docker image with Buildx

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -10,9 +10,15 @@ on:
       additional-latest-tag-name:
         type: string
         default: ''
-      unstable-tag-name:
+      default-unstable-tag:
+        type: boolean
+        default: true
+      additional-unstable-tag-name:
         type: string
-        default: unstable
+        default: ''
+      release-tag-suffix:
+        type: string
+        default: ''
     secrets:
       gh-token:
         required: true
@@ -31,15 +37,22 @@ jobs:
 
       # Creates an expression to be used in docker/metadata-action
       - name: Expression for additional latest tag
-        id: latest-tag
+        id: additional-tags
         run: |
-          tagName="${{ inputs.additional-latest-tag-name }}"
-          if [[ -n ${tagName} ]]; then
-            expression="type=raw,value=${tagName},enable=${{ github.event_name == 'release' }}"
+          latestTagName="${{ inputs.additional-latest-tag-name }}"
+          if [[ -n ${latestTagName} ]]; then
+            latestExpression="type=raw,value=${latestTagName},enable=${{ github.event_name == 'release' }}"
           else
-            expression=""
+            latestExpression=""
           fi
-          echo "expression=${expression}" >> $GITHUB_OUTPUT
+          unstableTagName="${{ inputs.additional-unstable-tag-name }}"
+          if [[ -n ${unstableTagName} ]]; then
+            unstableExpression="type=raw,value=${unstableTagName},enable=${{ github.ref == format('refs/heads/{0}', 'develop') }}"
+          else
+            unstableExpression=""
+          fi
+          echo "latest-expression=${latestExpression}" >> $GITHUB_OUTPUT
+          echo "unstable-expression=${unstableExpression}" >> $GITHUB_OUTPUT
 
       # Extract metadata (tags, labels) for Docker
       - name: Extract Docker metadata
@@ -52,12 +65,13 @@ jobs:
           flavor: |
             latest=${{ inputs.default-latest-tag == true && 'auto' || 'false' }}
           tags: |
-            type=ref,event=tag
+            type=ref,event=tag,suffix=${{ inputs.release-tag-suffix == '' && '' || '-' }}${{ inputs.release-tag-suffix }}
             type=ref,event=pr
-            # set additional latest tag if available
-            ${{ steps.latest-tag.outputs.expression }}
+            # set additional tags if available
+            ${{ steps.additional-tags.outputs.latest-expression }}
+            ${{ steps.additional-tags.outputs.unstable-expression }}
             # set unstable tag for develop branch
-            type=raw,value=${{ inputs.unstable-tag-name }},enable=${{ github.ref == format('refs/heads/{0}', 'develop') }}
+            type=raw,value=unstable,enable=${{ inputs.default-unstable-tag == true && github.ref == format('refs/heads/{0}', 'develop') }}
 
       # Build Docker image with Buildx
       - name: Build Docker image


### PR DESCRIPTION
Now supporting default and custom latest tag, default and custom unstable tag and a release tag suffix.

Workflow input defaults:
- `default-latest-tag`: `true`
- `additional-latest-tag-name`: `''` (empty)
- `default-unstable-tag`: `true`
- `additional-unstable-tag-name`: `''` (empty)
- `release-tag-suffix`: `''` (empty)

Example
```yml
with:
  image-name: swissgrc/azure-pipelines-azurecli
  default-latest-tag: true
  additional-latest-tag-name: latest-net7
  default-unstable-tag: true
  additional-unstable-tag-name: unstable-net7
  release-tag-suffix: net7
```

results in
- `latest`, `latest-net7` and `<release-tag>-net7` for a release
- `unstable`, `unstable-net7` for a build on the `develop` branch
- `pr-<id>` for a pull-request build

Whereas this
```yml
with:
  image-name: swissgrc/azure-pipelines-azurecli
  default-latest-tag: false
  additional-latest-tag-name: latest-net6
  default-unstable-tag: false
  additional-unstable-tag-name: unstable-net6
  release-tag-suffix: net6
```

results in
- `latest-net6` and `<release-tag>-net6` for a release
- `unstable-net6` for a build on the `develop` branch
- `pr-<id>` for a pull-request build

Resolves #60 