### PR TITLE
Remove dash if release tag suffix is not set

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -65,7 +65,7 @@ jobs:
           flavor: |
             latest=${{ inputs.default-latest-tag == true && 'auto' || 'false' }}
           tags: |
-            type=ref,event=tag,suffix=${{ inputs.release-tag-suffix == '' && '' || '-' }}${{ inputs.release-tag-suffix }}
+            type=ref,event=tag,suffix=${{ inputs.release-tag-suffix != '' && '-' || '' }}${{ inputs.release-tag-suffix }}
             type=ref,event=pr
             # set additional tags if available
             ${{ steps.additional-tags.outputs.latest-expression }}


### PR DESCRIPTION
Default value for inputs variable seems not to be empty string, means the expression did not match.
Swap it fixes it.

Fixes #72 