### PR TITLE
Add Node.js 22 with .NET 9 repository

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -10,7 +10,7 @@ Here you will find:
 * [Docker CLI](https://github.com/swissgrc/docker-azure-pipelines-dockercli)
 * [Git](https://github.com/swissgrc/docker-azure-pipelines-git)
 * [.NET 8](https://github.com/swissgrc/docker-azure-pipelines-dotnet-8) | [.NET 9](https://github.com/swissgrc/docker-azure-pipelines-dotnet-9)
-* [Node.js 20 with .NET 8](https://github.com/swissgrc/docker-azure-pipelines-node20-net8) | [Node.js 22 with .NET 8](https://github.com/swissgrc/docker-azure-pipelines-node22-net8)
+* [Node.js 20 with .NET 8](https://github.com/swissgrc/docker-azure-pipelines-node20-net8) | [Node.js 22 with .NET 8](https://github.com/swissgrc/docker-azure-pipelines-node22-net8) | [Node.js 22 with .NET 9](https://github.com/swissgrc/docker-azure-pipelines-node22-net9)
 * [Eclipse Temurin OpenJDK 17](https://github.com/swissgrc/docker-azure-pipelines-openjdk-17) | [Eclipse Temurin OpenJDK 21](https://github.com/swissgrc/docker-azure-pipelines-openjdk-21)
 * [Azure CLI with .NET 8](https://github.com/swissgrc/docker-azure-pipelines-azurecli-net8)
 * [Terraform](https://github.com/swissgrc/docker-azure-pipelines-terraform)


### PR DESCRIPTION
Adds the new Node.js 22 with .NET 9 repository to the overview