### PR TITLE
Switch to SonarSource/sonarqube-scan-action

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@v4.1.0
+        uses: SonarSource/sonarqube-scan-action@1b442ee39ac3fa7c2acdd410208dcb2bcfaae6c4 # v4.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.gh-token }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.sonar-token }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@02ef91109b2d589e757aefcfb2854c2783fd7b19 # v4.0.0
+        uses: SonarSource/sonarqube-scan-action@v4.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.gh-token }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.sonar-token }}


### PR DESCRIPTION
As mentioned in #249, the old action is deprecated. This change makes the workflow use the replacement action.

Fixes #249