### PR TITLE
Remove Node.js 20 mentioning

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -10,7 +10,7 @@ Here you will find:
 * [Docker CLI](https://github.com/swissgrc/docker-azure-pipelines-dockercli)
 * [Git](https://github.com/swissgrc/docker-azure-pipelines-git)
 * [.NET 8](https://github.com/swissgrc/docker-azure-pipelines-dotnet-8) | [.NET 9](https://github.com/swissgrc/docker-azure-pipelines-dotnet-9)
-* [Node.js 20 with .NET 8](https://github.com/swissgrc/docker-azure-pipelines-node20-net8) | [Node.js 22 with .NET 8](https://github.com/swissgrc/docker-azure-pipelines-node22-net8) | [Node.js 22 with .NET 9](https://github.com/swissgrc/docker-azure-pipelines-node22-net9)
+* [Node.js 22 with .NET 8](https://github.com/swissgrc/docker-azure-pipelines-node22-net8) | [Node.js 22 with .NET 9](https://github.com/swissgrc/docker-azure-pipelines-node22-net9)
 * [Azure CLI with .NET 8](https://github.com/swissgrc/docker-azure-pipelines-azurecli-net8) | [Azure CLI with .NET 9](https://github.com/swissgrc/docker-azure-pipelines-azurecli-net9)
 * [Terraform](https://github.com/swissgrc/docker-azure-pipelines-terraform)
 * [Packer](https://github.com/swissgrc/docker-azure-pipelines-packer)
@@ -31,8 +31,6 @@ graph TB
     dotnet9[azure-pipelines-dotnet<br>9.x.x]
     click dotnet9 "https://github.com/swissgrc/docker-azure-pipelines-dotnet-9"
 
-    node20_8[azure-pipelines-node<br>20.x.x-net8]
-    click node20_8 "https://github.com/swissgrc/docker-azure-pipelines-node20-net8"
     node22_8[azure-pipelines-node<br>22.x.x-net8]
     click node22_8 "https://github.com/swissgrc/docker-azure-pipelines-node22-net8"
     node22_9[azure-pipelines-node<br>22.x.x-net9]
@@ -66,7 +64,6 @@ graph TB
     git --> dotnet8
     git --> dotnet9
 
-    dotnet8 --> node20_8
     dotnet8 --> node22_8
     dotnet9 --> node22_9
 


### PR DESCRIPTION
Removed reference to Node.js 20 with .NET 8 from the README.