### PR TITLE
Add azure-pipelines-sancus to README.md

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -12,6 +12,7 @@ Here you will find:
 * [`azure-pipelines-janus`](https://github.com/swissgrc/docker-azure-pipelines) — L3 deployment (Azure CLI, Terraform, Packer, Helm, kubectl)
 * [`azure-pipelines-mercury`](https://github.com/swissgrc/docker-azure-pipelines) — L3 end-to-end testing (Playwright)
 * [`azure-pipelines-hermes`](https://github.com/swissgrc/docker-azure-pipelines) — L3 dependency updates (Renovate)
+* [`azure-pipelines-sancus`](https://github.com/swissgrc/docker-azure-pipelines) — L3 code signing
 
 ```mermaid
 graph TB
@@ -30,6 +31,9 @@ graph TB
     hermes[azure-pipelines-hermes]
     click hermes "https://github.com/swissgrc/docker-azure-pipelines"
 
+    sancus[azure-pipelines-sancus]
+    click sancus "https://github.com/swissgrc/docker-azure-pipelines"
+
     %% External base image
     debian[debian:13-slim]
     click debian "https://hub.docker.com/_/debian"
@@ -40,6 +44,7 @@ graph TB
     vulcan --> janus
     vulcan --> mercury
     vulcan --> hermes
+    vulcan --> sancus
 ```
 
 Images are available from the [GitHub Container Registry](https://github.com/orgs/swissgrc/packages?ecosystem=container) under `ghcr.io/swissgrc/`.


### PR DESCRIPTION
This pull request updates the `profile/README.md` to document and visualize the addition of the `azure-pipelines-sancus` image, which is used for L3 code signing. The changes ensure that the new image is consistently represented in both the textual list and the architecture diagram.